### PR TITLE
Settings: Add icon for mobile plan

### DIFF
--- a/res/drawable/ic_mobile_plan.xml
+++ b/res/drawable/ic_mobile_plan.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (C) 2017 Cardinal-AOSP
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+         http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?android:attr/colorControlNormal">
+
+    <path
+        android:pathData="M0 0h24v24H0z" />
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M21 18v1c0 1.1-.9 2-2 2H5c-1.11 0-2-.9-2-2V5c0-1.1 .89 -2 2-2h14c1.1 0 2 .9 2
+2v1h-9c-1.11 0-2 .9-2 2v8c0 1.1 .89 2 2 2h9zm-9-2h10V8H12v8zm4-2.5c-.83
+0-1.5-.67-1.5-1.5s.67-1.5 1.5-1.5 1.5 .67 1.5 1.5-.67 1.5-1.5 1.5z" />
+
+</vector>

--- a/res/xml/network_and_internet.xml
+++ b/res/xml/network_and_internet.xml
@@ -69,6 +69,7 @@
     <com.android.settingslib.RestrictedPreference
         android:key="manage_mobile_plan"
         android:title="@string/manage_mobile_plan_title"
+        android:icon="@drawable/ic_mobile_plan"
         android:persistent="false"
         settings:userRestriction="no_config_mobile_networks"
         settings:useAdminDisabledSummary="true"/>


### PR DESCRIPTION
* all preference have icons except mobile plan, so add it to keep consistency
* Icons credit: https://material.io

Signed-off-by: Adarsh-MR <adarshmr1998@gmail.com>