### PR TITLE
[2/2] Vibrate on plug and creates a gesture option in "System" screen of Settings

### DIFF
--- a/res/values/aim_strings.xml
+++ b/res/values/aim_strings.xml
@@ -110,8 +110,10 @@
      <string name="app_ops_boot_completed">auto start</string>
 
 <!-- Wakeup options -->
-     <string name="wakeup_when_plugged_unplugged_title">Wake up on charge</string>
-     <string name="wakeup_when_plugged_unplugged_summary">Wake up device if charger is plugged/unplugged.</string>
+     <string name="wakeup_when_plugged_unplugged_title">Wake up on plug</string>
+     <string name="wakeup_when_plugged_unplugged_summary">Wake up device if charger is plugged/unplugged.</string> 
+     <string name="vibration_on_charge_state_changed_title">Vibrate on plug</string>
+     <string name="vibration_on_charge_state_changed_summary">Vibrate when connecting or disconnecting a power source</string>
  
 <!-- UI debug setting: show CPU info? [CHAR LIMIT=25] -->
      <string name="show_cpu_info">Show CPU info</string>

--- a/res/xml/gestures_prefs.xml
+++ b/res/xml/gestures_prefs.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/*
+ * Copyright 2008, The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+        android:title="@string/input_methods_settings_title">
+
+    <PreferenceCategory
+        android:key="gesture_settings_category"
+        android:title="@string/gesture_preference_title">
+
+        <Preference
+            android:key="gesture_assist_input_summary"
+            android:title="@string/assist_gesture_title"
+            android:fragment="com.android.settings.gestures.AssistGestureSettings"/>
+
+        <Preference
+            android:key="gesture_swipe_down_fingerprint_input_summary"
+            android:title="@string/fingerprint_swipe_for_notifications_title"
+            android:fragment="com.android.settings.gestures.SwipeToNotificationSettings"/>
+
+        <Preference
+            android:key="gesture_double_tap_power_input_summary"
+            android:title="@string/double_tap_power_for_camera_title"
+            android:fragment="com.android.settings.gestures.DoubleTapPowerSettings"/>
+
+        <Preference
+            android:key="gesture_double_twist_input_summary"
+            android:title="@string/double_twist_for_camera_mode_title"
+            android:fragment="com.android.settings.gestures.DoubleTwistGestureSettings"/>
+
+        <Preference
+            android:key="gesture_double_tap_screen_input_summary"
+            android:title="@string/ambient_display_title"
+            android:fragment="com.android.settings.gestures.DoubleTapScreenSettings"/>
+
+        <Preference
+            android:key="gesture_pick_up_input_summary"
+            android:title="@string/ambient_display_pickup_title"
+            android:fragment="com.android.settings.gestures.PickupGestureSettings"/>
+
+    </PreferenceCategory>
+</PreferenceScreen>

--- a/res/xml/language_and_input.xml
+++ b/res/xml/language_and_input.xml
@@ -61,40 +61,6 @@
             android:title="@string/user_dict_settings_title"/>
     </PreferenceCategory>
 
-    <PreferenceCategory
-        android:key="gesture_settings_category"
-        android:title="@string/gesture_preference_title">
-
-        <Preference
-            android:key="gesture_assist_input_summary"
-            android:title="@string/assist_gesture_title"
-            android:fragment="com.android.settings.gestures.AssistGestureSettings"/>
-
-        <Preference
-            android:key="gesture_swipe_down_fingerprint_input_summary"
-            android:title="@string/fingerprint_swipe_for_notifications_title"
-            android:fragment="com.android.settings.gestures.SwipeToNotificationSettings"/>
-
-        <Preference
-            android:key="gesture_double_tap_power_input_summary"
-            android:title="@string/double_tap_power_for_camera_title"
-            android:fragment="com.android.settings.gestures.DoubleTapPowerSettings"/>
-
-        <Preference
-            android:key="gesture_double_twist_input_summary"
-            android:title="@string/double_twist_for_camera_mode_title"
-            android:fragment="com.android.settings.gestures.DoubleTwistGestureSettings"/>
-
-        <Preference
-            android:key="gesture_double_tap_screen_input_summary"
-            android:title="@string/ambient_display_title"
-            android:fragment="com.android.settings.gestures.DoubleTapScreenSettings"/>
-
-        <Preference
-            android:key="gesture_pick_up_input_summary"
-            android:title="@string/ambient_display_pickup_title"
-            android:fragment="com.android.settings.gestures.PickupGestureSettings"/>
-
         <com.android.settings.PointerSpeedPreference
             android:key="pointer_speed"
             android:title="@string/pointer_speed"

--- a/res/xml/power_usage_summary.xml
+++ b/res/xml/power_usage_summary.xml
@@ -49,6 +49,12 @@
             android:title="@string/wakeup_when_plugged_unplugged_title"
             android:summary="@string/wakeup_when_plugged_unplugged_summary"
             android:defaultValue="true" />
+	
+	<com.aim.freedomhub.preference.GlobalSettingSwitchPreference
+	    android:key="vibration_on_charge_state_changed"
+	    android:title="@string/vibration_on_charge_state_changed_title"
+	    android:summary="@string/vibration_on_charge_state_changed_summary"
+            android:defaultValue="true" />
 
         <SwitchPreference
             android:key="battery_percentage"

--- a/res/xml/system_dashboard_fragment.xml
+++ b/res/xml/system_dashboard_fragment.xml
@@ -18,6 +18,15 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:title="@string/header_category_system">
 
+    <!-- Gestures -->
+    <Preference
+        android:key="gestures_dashboard"
+        android:title="@string/gesture_preference_title"
+        android:summary="@string/gesture_preference_summary"
+        android:icon="@drawable/ic_settings_gestures"
+        android:order="-90"
+        android:fragment="com.android.settings.system.GesturesFragment" />
+
     <!-- Backup -->
     <Preference
         android:key="backup_settings"

--- a/src/com/android/settings/core/gateway/SettingsGateway.java
+++ b/src/com/android/settings/core/gateway/SettingsGateway.java
@@ -112,6 +112,7 @@ import com.android.settings.print.PrintJobSettingsFragment;
 import com.android.settings.print.PrintSettingsFragment;
 import com.android.settings.security.LockscreenDashboardFragment;
 import com.android.settings.sim.SimSettings;
+import com.android.settings.system.GesturesFragment;
 import com.android.settings.system.ResetDashboardFragment;
 import com.android.settings.system.SystemDashboardFragment;
 import com.android.settings.tts.TextToSpeechSettings;
@@ -237,6 +238,7 @@ public class SettingsGateway {
             WifiAPITest.class.getName(),
             WifiInfo.class.getName(),
             MasterClear.class.getName(),
+            GesturesFragment.class.getName(),
             ResetDashboardFragment.class.getName(),
             NightDisplaySettings.class.getName(),
             ManageDomainUrls.class.getName(),

--- a/src/com/android/settings/language/LanguageAndInputSettings.java
+++ b/src/com/android/settings/language/LanguageAndInputSettings.java
@@ -19,18 +19,13 @@ package com.android.settings.language;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.pm.PackageManager;
-import android.os.UserHandle;
 import android.provider.SearchIndexableResource;
 import android.provider.Settings;
 import android.speech.tts.TtsEngines;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.support.annotation.VisibleForTesting;
 import android.text.TextUtils;
 import android.view.inputmethod.InputMethodInfo;
 import android.view.inputmethod.InputMethodManager;
 
-import com.android.internal.hardware.AmbientDisplayConfiguration;
 import com.android.internal.logging.nano.MetricsProto;
 import com.android.settings.R;
 import com.android.settings.applications.defaultapps.DefaultAutofillPreferenceController;
@@ -38,12 +33,6 @@ import com.android.settings.core.PreferenceController;
 import com.android.settings.core.lifecycle.Lifecycle;
 import com.android.settings.dashboard.DashboardFragment;
 import com.android.settings.dashboard.SummaryLoader;
-import com.android.settings.gestures.AssistGesturePreferenceController;
-import com.android.settings.gestures.DoubleTapPowerPreferenceController;
-import com.android.settings.gestures.DoubleTapScreenPreferenceController;
-import com.android.settings.gestures.DoubleTwistPreferenceController;
-import com.android.settings.gestures.PickupGesturePreferenceController;
-import com.android.settings.gestures.SwipeToNotificationPreferenceController;
 import com.android.settings.inputmethod.GameControllerPreferenceController;
 import com.android.settings.inputmethod.PhysicalKeyboardPreferenceController;
 import com.android.settings.inputmethod.SpellCheckerPreferenceController;
@@ -59,14 +48,6 @@ public class LanguageAndInputSettings extends DashboardFragment {
     private static final String TAG = "LangAndInputSettings";
 
     private static final String KEY_TEXT_TO_SPEECH = "tts_settings_summary";
-    private static final String KEY_ASSIST = "gesture_assist_input_summary";
-    private static final String KEY_SWIPE_DOWN = "gesture_swipe_down_fingerprint_input_summary";
-    private static final String KEY_DOUBLE_TAP_POWER = "gesture_double_tap_power_input_summary";
-    private static final String KEY_DOUBLE_TWIST = "gesture_double_twist_input_summary";
-    private static final String KEY_DOUBLE_TAP_SCREEN = "gesture_double_tap_screen_input_summary";
-    private static final String KEY_PICK_UP = "gesture_pick_up_input_summary";
-
-    private AmbientDisplayConfiguration mAmbientDisplayConfig;
 
     @Override
     public int getMetricsCategory() {
@@ -91,16 +72,11 @@ public class LanguageAndInputSettings extends DashboardFragment {
 
     @Override
     protected List<PreferenceController> getPreferenceControllers(Context context) {
-        if (mAmbientDisplayConfig == null) {
-            mAmbientDisplayConfig = new AmbientDisplayConfiguration(context);
-        }
-
-        return buildPreferenceControllers(context, getLifecycle(), mAmbientDisplayConfig);
+        return buildPreferenceControllers(context, getLifecycle());
     }
 
-    private static List<PreferenceController> buildPreferenceControllers(@NonNull Context context,
-            @Nullable Lifecycle lifecycle,
-            @NonNull AmbientDisplayConfiguration ambientDisplayConfiguration) {
+    private static List<PreferenceController> buildPreferenceControllers(Context context,
+            Lifecycle lifecycle) {
         final List<PreferenceController> controllers = new ArrayList<>();
         // Language
         controllers.add(new PhoneLanguagePreferenceController(context));
@@ -117,24 +93,8 @@ public class LanguageAndInputSettings extends DashboardFragment {
         }
 
         controllers.add(gameControllerPreferenceController);
-        // Gestures
-        controllers.add(new AssistGesturePreferenceController(context, lifecycle, KEY_ASSIST));
-        controllers.add(new SwipeToNotificationPreferenceController(context, lifecycle,
-                KEY_SWIPE_DOWN));
-        controllers.add(new DoubleTwistPreferenceController(context, lifecycle, KEY_DOUBLE_TWIST));
-        controllers.add(new DoubleTapPowerPreferenceController(context, lifecycle,
-                KEY_DOUBLE_TAP_POWER));
-        controllers.add(new PickupGesturePreferenceController(context, lifecycle,
-                ambientDisplayConfiguration, UserHandle.myUserId(), KEY_PICK_UP));
-        controllers.add(new DoubleTapScreenPreferenceController(context, lifecycle,
-                ambientDisplayConfiguration, UserHandle.myUserId(), KEY_DOUBLE_TAP_SCREEN));
         controllers.add(new DefaultAutofillPreferenceController(context));
         return controllers;
-    }
-
-    @VisibleForTesting
-    void setAmbientDisplayConfig(AmbientDisplayConfiguration ambientConfig) {
-        mAmbientDisplayConfig = ambientConfig;
     }
 
     private static class SummaryProvider implements SummaryLoader.SummaryProvider {
@@ -186,8 +146,7 @@ public class LanguageAndInputSettings extends DashboardFragment {
 
                 @Override
                 public List<PreferenceController> getPreferenceControllers(Context context) {
-                    return buildPreferenceControllers(context, null,
-                            new AmbientDisplayConfiguration(context));
+                    return buildPreferenceControllers(context, null /* lifecycle */);
                 }
 
                 @Override
@@ -195,12 +154,6 @@ public class LanguageAndInputSettings extends DashboardFragment {
                     List<String> keys = super.getNonIndexableKeys(context);
                     // Duplicates in summary and details pages.
                     keys.add(KEY_TEXT_TO_SPEECH);
-                    keys.add(KEY_ASSIST);
-                    keys.add(KEY_SWIPE_DOWN);
-                    keys.add(KEY_DOUBLE_TAP_POWER);
-                    keys.add(KEY_DOUBLE_TWIST);
-                    keys.add(KEY_DOUBLE_TAP_SCREEN);
-                    keys.add(KEY_PICK_UP);
 
                     return keys;
                 }

--- a/src/com/android/settings/search/SearchIndexableResources.java
+++ b/src/com/android/settings/search/SearchIndexableResources.java
@@ -74,6 +74,7 @@ import com.android.settings.notification.ZenModeVisualInterruptionSettings;
 import com.android.settings.print.PrintSettingsFragment;
 import com.android.settings.security.LockscreenDashboardFragment;
 import com.android.settings.sim.SimSettings;
+import com.android.settings.system.GesturesFragment;
 import com.android.settings.system.ResetDashboardFragment;
 import com.android.settings.system.SystemDashboardFragment;
 import com.android.settings.tts.TtsEnginePreferenceFragment;
@@ -166,6 +167,7 @@ public final class SearchIndexableResources {
                 R.xml.zen_mode_visual_interruptions_settings,
                 R.drawable.ic_settings_notifications);
         addIndex(SystemDashboardFragment.class, NO_DATA_RES_ID, R.drawable.ic_settings_about);
+        addIndex(GesturesFragment.class, NO_DATA_RES_ID, R.drawable.ic_settings_gestures);
         addIndex(ResetDashboardFragment.class, NO_DATA_RES_ID, R.drawable.ic_restore);
         addIndex(StorageDashboardFragment.class, NO_DATA_RES_ID, R.drawable.ic_settings_storage);
         addIndex(ConnectedDeviceDashboardFragment.class, NO_DATA_RES_ID,

--- a/src/com/android/settings/system/GesturesFragment.java
+++ b/src/com/android/settings/system/GesturesFragment.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (C) 2017 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.settings.system;
+
+import android.content.ComponentName;
+import android.content.Context;
+import android.os.UserHandle;
+import android.provider.SearchIndexableResource;
+import android.provider.Settings;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.annotation.VisibleForTesting;
+
+import com.android.internal.hardware.AmbientDisplayConfiguration;
+import com.android.internal.logging.nano.MetricsProto;
+import com.android.settings.R;
+import com.android.settings.core.PreferenceController;
+import com.android.settings.core.lifecycle.Lifecycle;
+import com.android.settings.dashboard.DashboardFragment;
+import com.android.settings.gestures.AssistGesturePreferenceController;
+import com.android.settings.gestures.DoubleTapPowerPreferenceController;
+import com.android.settings.gestures.DoubleTapScreenPreferenceController;
+import com.android.settings.gestures.DoubleTwistPreferenceController;
+import com.android.settings.gestures.PickupGesturePreferenceController;
+import com.android.settings.gestures.SwipeToNotificationPreferenceController;
+import com.android.settings.search.BaseSearchIndexProvider;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class GesturesFragment extends DashboardFragment {
+
+    private static final String TAG = "GesturesFragment";
+
+    private static final String KEY_ASSIST = "gesture_assist_input_summary";
+    private static final String KEY_SWIPE_DOWN = "gesture_swipe_down_fingerprint_input_summary";
+    private static final String KEY_DOUBLE_TAP_POWER = "gesture_double_tap_power_input_summary";
+    private static final String KEY_DOUBLE_TWIST = "gesture_double_twist_input_summary";
+    private static final String KEY_DOUBLE_TAP_SCREEN = "gesture_double_tap_screen_input_summary";
+    private static final String KEY_PICK_UP = "gesture_pick_up_input_summary";
+
+    private AmbientDisplayConfiguration mAmbientDisplayConfig;
+
+    @Override
+    public int getMetricsCategory() {
+        return MetricsProto.MetricsEvent.ABC;
+    }
+
+    @Override
+    protected String getLogTag() {
+        return TAG;
+    }
+
+    @Override
+    protected int getPreferenceScreenResId() {
+        return R.xml.gestures_prefs;
+    }
+
+    @Override
+    protected List<PreferenceController> getPreferenceControllers(Context context) {
+        if (mAmbientDisplayConfig == null) {
+            mAmbientDisplayConfig = new AmbientDisplayConfiguration(context);
+        }
+
+        return buildPreferenceControllers(context, getLifecycle(), mAmbientDisplayConfig);
+    }
+
+    private static List<PreferenceController> buildPreferenceControllers(@NonNull Context context,
+            @Nullable Lifecycle lifecycle,
+            @NonNull AmbientDisplayConfiguration ambientDisplayConfiguration) {
+        final List<PreferenceController> controllers = new ArrayList<>();
+        // Gestures
+        controllers.add(new AssistGesturePreferenceController(context, lifecycle, KEY_ASSIST));
+        controllers.add(new SwipeToNotificationPreferenceController(context, lifecycle,
+                KEY_SWIPE_DOWN));
+        controllers.add(new DoubleTwistPreferenceController(context, lifecycle, KEY_DOUBLE_TWIST));
+        controllers.add(new DoubleTapPowerPreferenceController(context, lifecycle,
+                KEY_DOUBLE_TAP_POWER));
+        controllers.add(new PickupGesturePreferenceController(context, lifecycle,
+                ambientDisplayConfiguration, UserHandle.myUserId(), KEY_PICK_UP));
+        controllers.add(new DoubleTapScreenPreferenceController(context, lifecycle,
+                ambientDisplayConfiguration, UserHandle.myUserId(), KEY_DOUBLE_TAP_SCREEN));
+        return controllers;
+    }
+
+    @VisibleForTesting
+    void setAmbientDisplayConfig(AmbientDisplayConfiguration ambientConfig) {
+        mAmbientDisplayConfig = ambientConfig;
+    }
+
+    public static final SearchIndexProvider SEARCH_INDEX_DATA_PROVIDER =
+            new BaseSearchIndexProvider() {
+                @Override
+                public List<SearchIndexableResource> getXmlResourcesToIndex(Context context,
+                        boolean enabled) {
+                    final ArrayList<SearchIndexableResource> result = new ArrayList<>();
+
+                    final SearchIndexableResource sir = new SearchIndexableResource(context);
+                    sir.xmlResId = R.xml.gestures_prefs;
+                    result.add(sir);
+                    return result;
+                }
+
+                @Override
+                public List<PreferenceController> getPreferenceControllers(Context context) {
+                    return buildPreferenceControllers(context, null,
+                            new AmbientDisplayConfiguration(context));
+                }
+
+                @Override
+                public List<String> getNonIndexableKeys(Context context) {
+                    List<String> keys = super.getNonIndexableKeys(context);
+                    // Duplicates in summary and details pages.
+                    keys.add(KEY_ASSIST);
+                    keys.add(KEY_SWIPE_DOWN);
+                    keys.add(KEY_DOUBLE_TAP_POWER);
+                    keys.add(KEY_DOUBLE_TWIST);
+                    keys.add(KEY_DOUBLE_TAP_SCREEN);
+                    keys.add(KEY_PICK_UP);
+
+                    return keys;
+                }
+            };
+}


### PR DESCRIPTION
This is part 2 of 2 for the commit regarding vibrate on plug and as a bonus,  add a gesture screen in System section of settings just like how it is in 8.1